### PR TITLE
Configurable Max Number of Occurrences Threshold

### DIFF
--- a/include/httpserver.h
+++ b/include/httpserver.h
@@ -73,6 +73,9 @@ struct ConnectionInfo
     string answerString;
     int answerCode;
 
+    // Arguments from query string
+    float threshold;
+
     vector<char> uploadedData;
 };
 

--- a/include/orb/orbindex.h
+++ b/include/orb/orbindex.h
@@ -61,7 +61,7 @@ public:
     unsigned getTotalNbIndexedImages();
     u_int32_t addImage(unsigned i_imageId, list<HitForward> hitList);
     u_int32_t removeImage(const unsigned i_imageId);
-    u_int32_t getImageWords(const unsigned i_imageId, unordered_map<u_int32_t, list<Hit> > &hitList);
+    u_int32_t getImageWords(const unsigned i_imageId, float threshold, unordered_map<u_int32_t, list<Hit> > &hitList);
     u_int32_t write(string backwardIndexPath);
     u_int32_t clear();
     u_int32_t load(string backwardIndexPath);

--- a/include/searcher.h
+++ b/include/searcher.h
@@ -41,6 +41,7 @@ struct SearchRequest
     vector<u_int32_t> results;
     vector<Rect> boundingRects;
     vector<float> scores;
+    float threshold;
 };
 
 

--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -146,6 +146,17 @@ int HTTPServer::answerToConnection(void *cls, MHD_Connection *connection,
 
         conInfo->url = string(url);
 
+        // Handle arguments from query string
+        conInfo->threshold = 0.15;
+
+        const char* threshold = MHD_lookup_connection_value(connection,
+            MHD_GET_ARGUMENT_KIND, "threshold");
+
+        if (threshold != NULL)
+        {
+            conInfo->threshold = atof(threshold);
+        }
+
         *conCls = (void *) conInfo;
 
         return MHD_YES;

--- a/src/orb/orbindex.cpp
+++ b/src/orb/orbindex.cpp
@@ -195,13 +195,13 @@ u_int32_t ORBIndex::removeImage(const unsigned i_imageId)
  * @brief Get a list of hits associated with an image id.
  * @param  the list of hits.
  */
-u_int32_t ORBIndex::getImageWords(unsigned i_imageId, unordered_map<u_int32_t, list<Hit> > &hitList)
+u_int32_t ORBIndex::getImageWords(unsigned i_imageId, float threshold, unordered_map<u_int32_t, list<Hit> > &hitList)
 {
     pthread_rwlock_wrlock(&rwLock);
 
     const unsigned i_nbTotalIndexedImages = getTotalNbIndexedImages();
     const unsigned i_maxNbOccurences = i_nbTotalIndexedImages > 10000 ?
-                                       0.15 * i_nbTotalIndexedImages
+                                       threshold * i_nbTotalIndexedImages
                                        : i_nbTotalIndexedImages;
 
     unordered_map<u_int64_t, vector<unsigned> >::iterator imgIt =

--- a/src/orb/orbsearcher.cpp
+++ b/src/orb/orbsearcher.cpp
@@ -133,7 +133,7 @@ u_int32_t ORBSearcher::searchImage(SearchRequest &request)
 
     const unsigned i_nbTotalIndexedImages = index->getTotalNbIndexedImages();
     const unsigned i_maxNbOccurences = i_nbTotalIndexedImages > 10000 ?
-                                       0.15 * i_nbTotalIndexedImages
+                                       request.threshold * i_nbTotalIndexedImages
                                        : i_nbTotalIndexedImages;
 
     unordered_map<u_int32_t, list<Hit> > imageReqHits; // key: visual word, value: the found angles
@@ -187,7 +187,7 @@ u_int32_t ORBSearcher::searchSimilar(SearchRequest &request)
 
     // key: visual word, value: the found angles
     unordered_map<u_int32_t, list<Hit> > imageReqHits;
-    u_int32_t i_ret = index->getImageWords(request.imageId, imageReqHits);
+    u_int32_t i_ret = index->getImageWords(request.imageId, request.threshold, imageReqHits);
 
     if (i_ret != OK)
         return i_ret;

--- a/src/requesthandler.cpp
+++ b/src/requesthandler.cpp
@@ -157,6 +157,8 @@ void RequestHandler::handleRequest(ConnectionInfo &conInfo)
 
         req.imageData = conInfo.uploadedData;
         req.client = NULL;
+        req.threshold = conInfo.threshold;
+
         u_int32_t i_ret = imageSearcher->searchImage(req);
 
         ret["type"] = Converter::codeToString(i_ret);
@@ -194,6 +196,8 @@ void RequestHandler::handleRequest(ConnectionInfo &conInfo)
 
         req.imageId = atoi(parsedURI[2].c_str());
         req.client = NULL;
+        req.threshold = conInfo.threshold;
+
         u_int32_t i_ret = imageSearcher->searchSimilar(req);
 
         ret["type"] = Converter::codeToString(i_ret);


### PR DESCRIPTION
Make it so that a query string parameter (`?threshold=0.15`) can be provided to the similarity methods (both image uploads and in-index similarity). This allows you to selectively scale the max threshold without having to re-compile Pastec. This can give the user the ability to optionally choose between faster performance at the expense of less matches, or slower performance and more matches (but decreased accuracy).
