### PR TITLE
Implement auto-saving of the index after a change has happened.

### DIFF
--- a/include/orb/orbfeatureextractor.h
+++ b/include/orb/orbfeatureextractor.h
@@ -27,6 +27,7 @@
 #include <list>
 
 #include <opencv2/core/core.hpp>
+#include <opencv2/features2d/features2d.hpp>
 
 #include <orbindex.h>
 #include <orbwordindex.h>
@@ -51,6 +52,7 @@ public:
 private:
     ORBIndex *index;
     ORBWordIndex *wordIndex;
+    Ptr<ORB> orb;
 };
 
 #endif // PASTEC_ORBFEATUREEXTRACTOR_H

--- a/include/orb/orbindex.h
+++ b/include/orb/orbindex.h
@@ -52,7 +52,7 @@ using namespace std::tr1;
 class ORBIndex : public Index
 {
 public:
-    ORBIndex(string indexPath, bool cacheImageWords);
+    ORBIndex(string indexPath, bool cacheImageWords, unsigned int autoSaveInterval);
     virtual ~ORBIndex();
     void getImagesWithVisualWords(unordered_map<u_int32_t, list<Hit> > &imagesReqHits,
                                   unordered_map<u_int32_t, vector<Hit> > &indexHitsForReq);
@@ -68,12 +68,16 @@ public:
     u_int32_t getImageIds(vector<u_int32_t> &imageIds);
     void readLock();
     void unlock();
+    unsigned int autoSaveInterval;
+    bool hasUnsavedChanges;
 
 private:
     bool readIndex(string backwardIndexPath);
+    static void* autoSaveIndex(void *index_ptr);
 
     u_int64_t nbOccurences[NB_VISUAL_WORDS];
     u_int64_t totalNbRecords;
+    string indexPath;
     bool cacheImageWords;
 
     unordered_map<u_int64_t, unsigned> nbWords;

--- a/include/orb/orbsearcher.h
+++ b/include/orb/orbsearcher.h
@@ -57,6 +57,7 @@ private:
     ORBIndex *index;
     ORBWordIndex *wordIndex;
     ImageReranker reranker;
+    Ptr<ORB> orb;
 };
 
 #endif // PASTEC_IMAGESEARCHER_H

--- a/include/orb/orbwordindex.h
+++ b/include/orb/orbwordindex.h
@@ -25,7 +25,7 @@
 #include <vector>
 
 #include <opencv2/core/core.hpp>
-#include <opencv2/flann/flann.hpp>
+#include <opencv2/flann.hpp>
 
 using namespace cv;
 using namespace std;

--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -21,6 +21,7 @@
 
 #include <iostream>
 
+#include <stdlib.h>
 #include <sys/types.h>
 #include <sys/select.h>
 #include <sys/socket.h>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -64,6 +64,7 @@ int main(int argc, char** argv)
     }
 
     unsigned i_port = 4212;
+    unsigned int autoSaveInterval = 0;
     string visualWordPath;
     string indexPath(DEFAULT_INDEX_PATH);
     bool cacheImageWords = false;
@@ -81,6 +82,11 @@ int main(int argc, char** argv)
             EXIT_IF_LAST_ARGUMENT()
             indexPath = argv[++i];
         }
+        else if (string(argv[i]) == "--auto-save")
+        {
+            EXIT_IF_LAST_ARGUMENT()
+            autoSaveInterval = atoi(argv[++i]);
+        }
         else if (string(argv[i]) == "--cache-words")
         {
             cacheImageWords = true;
@@ -97,7 +103,7 @@ int main(int argc, char** argv)
         ++i;
     }
 
-    Index *index = new ORBIndex(indexPath, cacheImageWords);
+    Index *index = new ORBIndex(indexPath, cacheImageWords, autoSaveInterval);
     ORBWordIndex *wordIndex = new ORBWordIndex(visualWordPath);
     FeatureExtractor *ife = new ORBFeatureExtractor((ORBIndex *)index, wordIndex);
     Searcher *is = new ORBSearcher((ORBIndex *)index, wordIndex);

--- a/src/orb/orbfeatureextractor.cpp
+++ b/src/orb/orbfeatureextractor.cpp
@@ -29,7 +29,6 @@
 
 #include <opencv2/highgui/highgui.hpp>
 #include <opencv2/imgproc/imgproc.hpp>
-#include <opencv2/features2d/features2d.hpp>
 
 #include <orbfeatureextractor.h>
 #include <messages.h>
@@ -37,7 +36,7 @@
 
 
 ORBFeatureExtractor::ORBFeatureExtractor(ORBIndex *index, ORBWordIndex *wordIndex)
-    : index(index), wordIndex(wordIndex)
+    : index(index), wordIndex(wordIndex), orb(ORB::create(2000, 1.02, 100))
 { }
 
 
@@ -54,7 +53,7 @@ u_int32_t ORBFeatureExtractor::processNewImage(unsigned i_imageId, unsigned i_im
     vector<KeyPoint> keypoints;
     Mat descriptors;
 
-    ORB(2000, 1.02, 100)(img, noArray(), keypoints, descriptors);
+    orb->detectAndCompute(img, noArray(), keypoints, descriptors);
     i_nbFeaturesExtracted = keypoints.size();
 
     unsigned i_nbKeyPoints = 0;

--- a/src/orb/orbindex.cpp
+++ b/src/orb/orbindex.cpp
@@ -22,6 +22,7 @@
 #include <iostream>
 #include <string>
 #include <sstream>
+#include <unistd.h>
 #include <cstdlib>
 #include <algorithm>
 #include <sys/time.h>

--- a/src/orb/orbindex.cpp
+++ b/src/orb/orbindex.cpp
@@ -228,7 +228,7 @@ u_int32_t ORBIndex::removeImage(const unsigned i_imageId)
  */
 u_int32_t ORBIndex::getImageWords(unsigned i_imageId, float threshold, unordered_map<u_int32_t, list<Hit> > &hitList)
 {
-    pthread_rwlock_wrlock(&rwLock);
+    //pthread_rwlock_wrlock(&rwLock);
 
     const unsigned i_nbTotalIndexedImages = getTotalNbIndexedImages();
     const unsigned i_maxNbOccurences = i_nbTotalIndexedImages > 10000 ?
@@ -294,7 +294,7 @@ u_int32_t ORBIndex::getImageWords(unsigned i_imageId, float threshold, unordered
         }
     }
 
-    pthread_rwlock_unlock(&rwLock);
+    //pthread_rwlock_unlock(&rwLock);
 
     cout << "Image " << i_imageId << " found with " << hitList.size() << " words." << endl;
 

--- a/src/orb/orbsearcher.cpp
+++ b/src/orb/orbsearcher.cpp
@@ -46,7 +46,7 @@ using namespace std::tr1;
 #endif
 
 ORBSearcher::ORBSearcher(ORBIndex *index, ORBWordIndex *wordIndex)
-    : index(index), wordIndex(wordIndex)
+    : index(index), wordIndex(wordIndex), orb(ORB::create(2000, 1.02, 100))
 { }
 
 
@@ -124,7 +124,7 @@ u_int32_t ORBSearcher::searchImage(SearchRequest &request)
     vector<KeyPoint> keypoints;
     Mat descriptors;
 
-    ORB(2000, 1.02, 100)(img, noArray(), keypoints, descriptors);
+    orb->detectAndCompute(img, noArray(), keypoints, descriptors);
 
     gettimeofday(&t[1], NULL);
 


### PR DESCRIPTION
This diff implements two changes:

1) It makes it so that if you save the index with no specified file name then it'll automatically save to the last file that the data was read from. This makes it so that the client no longer has to know about where index files should be saved.
2) It provides a new, optional, command-line option (`--auto-save [DELAY]`) that you can use to enabling saving of the index. Given the specified delay, in seconds, it will attempt to save the index every `DELAY` seconds, but only if something has recently changed (such as an image being added, or removed, or the index cleared).

Thus the client will no longer have to manually manage saving the index state.
